### PR TITLE
Change link to #libbitcoin IRC

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -6,7 +6,7 @@
 				</p>
               <p>libbitcoin believes in the revoltionary promise of Satoshi's original protocol. </p>  
                     <p>The libbitcoin development project aims to create an extendable, scalable and configurable architecture, along with useful software. Making Bitcoin super-pluggable, highly configurable and easy to interact with.</p>
-                    <p>Communication, development and support occurs on the <a href="https://mailinglists.dyne.org/cgi-bin/mailman/listinfo/libbitcoin">libbitcoin mailing list</a>, <a href="http://webchat.freenode.net/?channels=%23darkwallet&uio=d4">Freenode IRC #darkwallet</a> and the <a href="https://wiki.unsystem.net/">unSYSTEM wiki</a>.</p>
+                    <p>Communication, development and support occurs on the <a href="https://mailinglists.dyne.org/cgi-bin/mailman/listinfo/libbitcoin">libbitcoin mailing list</a>, <a href="http://webchat.freenode.net/?channels=%23libbitcoin&uio=d4">Freenode IRC #libbitcoin</a> and the <a href="https://wiki.unsystem.net/">unSYSTEM wiki</a>.</p>
 			</div>
 			<div class="box" id="content-box1">
 				<h3>Our Values</h3>


### PR DESCRIPTION
Wiki seems to be down too.
Maybe move that to a Github repo wiki, if possible.
